### PR TITLE
Feature/utf8 output

### DIFF
--- a/ShimCacheParser.py
+++ b/ShimCacheParser.py
@@ -23,6 +23,7 @@ import zipfile
 import argparse
 import binascii
 import datetime
+import codecs
 import cStringIO as sio
 import xml.etree.cElementTree as et
 from os import path
@@ -62,6 +63,7 @@ CACHE_MAGIC_NT6_4 = 0x30
 
 bad_entry_data = 'N/A'
 g_verbose = False
+g_usebom = False
 output_header  = ["Last Modified", "Last Update", "Path", "File Size", "Exec Flag"]
 
 #Date Formats
@@ -166,9 +168,13 @@ def write_it(rows, outfile=None):
                 print " ".join(["%s"%x for x in row])
         else:
             print "[+] Writing output to %s..."%outfile
-            try:    
-                csv_writer = writer(file(outfile, 'wb'), delimiter=',')
+            try:
+                f = open(outfile, 'wb')
+                if g_usebom:
+                    f.write(codecs.BOM_UTF8)    
+                csv_writer = writer(f, delimiter=',')
                 csv_writer.writerows(rows)
+                f.close()
             except IOError, err:
                 print "[-] Error writing output file: %s" % str(err)
                 return
@@ -832,15 +838,18 @@ def main():
     
     global g_verbose
     global g_timeformat
+    global g_usebom
     
     parser = argparse.ArgumentParser(description="Parses Application Compatibilty Shim Cache data")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Toggles verbose output")
     parser.add_argument("-t","--ustime", action="store_const", dest="timeformat", const=DATE_MDY, default=DATE_ISO,
         help="Use MM/DD/YY instead of default YYYY-MM-DD ISO format")
+    parser.add_argument("-B", "--bom", action="store_true", help="Write UTF8 BOM to CSV for easier Excel 2007+ import")
     
     group = parser.add_argument_group()
-    group.add_argument("-o", "--out", metavar="FILE", help="Writes to CSV data to FILE (default is STDOUT)")
+    group.add_argument("-o", "--out", metavar="FILE", help="Writes CSV data to FILE (default is STDOUT)")
+    
     
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-l", "--local", action="store_true", help="Reads data from local system")
@@ -857,6 +866,10 @@ def main():
 
     # Set date/time format
     g_timeformat = args.timeformat
+
+    # Enable UTF8 Byte Order Mark (BOM) so Excel imports correctly
+    if args.bom:
+        g_usebom = True
 
     # Pull Shim Cache MIR XML.
     if args.mir:

--- a/ShimCacheParser.py
+++ b/ShimCacheParser.py
@@ -64,6 +64,10 @@ bad_entry_data = 'N/A'
 g_verbose = False
 output_header  = ["Last Modified", "Last Update", "Path", "File Size", "Exec Flag"]
 
+#Date Formats
+DATE_MDY = "%m/%d/%y %H:%M:%S"
+DATE_ISO = "%Y-%m-%d %H:%M:%S"
+
 # Shim Cache format used by Windows 5.2 and 6.0 (Server 2003 through Vista/Server 2008)
 class CacheEntryNt5(object):
     
@@ -310,7 +314,7 @@ def read_win8_entries(bin_data, ver_magic):
 
         last_mod_date = convert_filetime(low_datetime, high_datetime)
         try:
-            last_mod_date = last_mod_date.strftime("%m/%d/%y %H:%M:%S")
+            last_mod_date = last_mod_date.strftime(g_timeformat)
         except ValueError:
             last_mod_date = bad_entry_data
 
@@ -353,7 +357,7 @@ def read_win10_entries(bin_data, ver_magic):
 
         last_mod_date = convert_filetime(low_datetime, high_datetime)
         try:
-            last_mod_date = last_mod_date.strftime("%m/%d/%y %H:%M:%S")
+            last_mod_date = last_mod_date.strftime(g_timeformat)
         except ValueError:
             last_mod_date = bad_entry_data
 
@@ -399,7 +403,7 @@ def read_nt5_entries(bin_data, entry):
         
             last_mod_date = convert_filetime(entry.dwLowDateTime, entry.dwHighDateTime)
             try:
-                last_mod_date = last_mod_date.strftime("%m/%d/%y %H:%M:%S")
+                last_mod_date = last_mod_date.strftime(g_timeformat)
             except ValueError:
                 last_mod_date = bad_entry_data
             path = bin_data[entry.Offset:entry.Offset + entry.wLength].decode('utf-16le', 'replace').encode('utf-8')
@@ -451,7 +455,7 @@ def read_nt6_entries(bin_data, entry):
             last_mod_date = convert_filetime(entry.dwLowDateTime,
                                              entry.dwHighDateTime)
             try:
-                last_mod_date = last_mod_date.strftime("%m/%d/%y %H:%M:%S")
+                last_mod_date = last_mod_date.strftime(g_timeformat)
             except ValueError:
                 last_mod_date = 'N/A'
             path = (bin_data[entry.Offset:entry.Offset +
@@ -507,7 +511,7 @@ def read_winxp_entries(bin_data):
             last_mod_time = struct.unpack('<2L', bin_data[entry_data:entry_data+8])
             try:
                 last_mod_time = convert_filetime(last_mod_time[0],
-                                                 last_mod_time[1]).strftime("%m/%d/%y %H:%M:%S")
+                                                 last_mod_time[1]).strftime(g_timeformat)
             except ValueError:
                 last_mod_time = 'N/A'
                 
@@ -520,7 +524,7 @@ def read_winxp_entries(bin_data):
             exec_time = struct.unpack('<2L', bin_data[entry_data + 16:entry_data + 24])
             try:
                 exec_time = convert_filetime(exec_time[0],
-                                             exec_time[1]).strftime("%m/%d/%y %H:%M:%S")
+                                             exec_time[1]).strftime(g_timeformat)
             except ValueError:
                 exec_time = bad_entry_data
                 
@@ -827,10 +831,13 @@ def read_zip(zip_name):
 def main():
     
     global g_verbose
+    global g_timeformat
     
     parser = argparse.ArgumentParser(description="Parses Application Compatibilty Shim Cache data")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Toggles verbose output")
+    parser.add_argument("-t","--ustime", action="store_const", dest="timeformat", const=DATE_MDY, default=DATE_ISO,
+        help="Use MM/DD/YY instead of default YYYY-MM-DD ISO format")
     
     group = parser.add_argument_group()
     group.add_argument("-o", "--out", metavar="FILE", help="Writes to CSV data to FILE (default is STDOUT)")
@@ -847,6 +854,9 @@ def main():
 
     if args.verbose:
         g_verbose = True
+
+    # Set date/time format
+    g_timeformat = args.timeformat
 
     # Pull Shim Cache MIR XML.
     if args.mir:


### PR DESCRIPTION
- Enable option to output UTF8 BOM to CSV file to enable easier UTF8 import in to Excel 2007+.

  Although a UTF8 Byte Order Mark (BOM) is considered a bad idea for UTF8 files in general, Excel assumes a single-byte format for a CSV and this ends up rendering Unicode filenames incorrectly. By forcing a UTF8 BOM to be written, Excel 2007+ should automatically import the CSV as UTF8 when it is double-clicked. This is easier than using the import wizard.

  The option must be explicitly enabled. The default output mode remains intact to prevent problems like combining files and running in to problems because of an unexpected BOM.

_Note: This feature was built on the version that also includes the modification to the date formatting, submitted in a separate request._