### PR TITLE
Update ShimCacheParser.py

### DIFF
--- a/ShimCacheParser.py
+++ b/ShimCacheParser.py
@@ -498,7 +498,7 @@ def read_winxp_entries(bin_data):
             return None
 
         for offset in xrange(WINXP_HEADER_SIZE32,
-                             (num_entries*WINXP_ENTRY_SIZE32), WINXP_ENTRY_SIZE32):
+                             (num_entries*WINXP_ENTRY_SIZE32) + WINXP_HEADER_SIZE32, WINXP_ENTRY_SIZE32):
 
             # No size values are included in these entries, so search for utf-16 terminator.
             path_len = bin_data[offset:offset+(MAX_PATH + 8)].find("\x00\x00")


### PR DESCRIPTION
Issue #9 was only present for NT6.1 systems due to the header being larger than an individual entry; however, for the sake of beautiful code and algorithm sake let the change be reflected for Windows XP.